### PR TITLE
Mark the Vaadin session as dirty after each request

### DIFF
--- a/src/main/java/com/hazelcast/FlushingFilter.java
+++ b/src/main/java/com/hazelcast/FlushingFilter.java
@@ -1,0 +1,50 @@
+package com.hazelcast;
+
+import java.io.IOException;
+import java.util.Enumeration;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import com.vaadin.flow.server.VaadinSession;
+
+@WebFilter("/*")
+public class FlushingFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        // nop
+    }
+
+    @Override
+    public void destroy() {
+        // nop
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        chain.doFilter(request, response);
+
+        if (request instanceof HttpServletRequest) {
+            HttpSession session = ((HttpServletRequest) request).getSession(false);
+            if (session == null) {
+                return;
+            }
+
+            for (Enumeration<String> attributeNames = session.getAttributeNames(); attributeNames.hasMoreElements();) {
+                String name = attributeNames.nextElement();
+                Object value = session.getAttribute(name);
+                if (value instanceof VaadinSession) {
+                    session.setAttribute(name, value);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
hazelcast-tomcat-sessionmanager is only concerned with those parts of a
session for which setAttribute has been called at least once during the
request. The way Vaadin only updates the contents of an existing
attribute means that the session manager is otherwise completely unaware
that anything might have changed.

There's mostly likely still a short window of opportunity for data to
become lost if a node goes down immediately after the request ends when
using P2P mode, but failover does still happen with some delay in this
way.

This filter is only a crude prototype. A proper implementation would
look at the session contents to determine whether anything related to
Vaadin has actually changed (i.e. changes to any sync id) and then do
setAttribute only when necessary.